### PR TITLE
get open_ai.register_mob() usable from other mods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1311,14 +1311,16 @@ open_ai.register_mob = function(name,def)
 	open_ai.spawn_table[name].spawn_node = def.spawn_node
 	open_ai.spawn_table[name].liquid_mob = def.liquid_mob
 	
-	--store default collision box globally
-	open_ai.defaults["open_ai:"..name] = {}
-	open_ai.defaults["open_ai:"..name]["collisionbox"] = table.copy(def.collisionbox)
+	local entity_name = minetest.get_current_modname()..":"..name
 	
-	minetest.register_entity("open_ai:"..name, {
+	--store default collision box globally
+	open_ai.defaults[entity_name] = {}
+	open_ai.defaults[entity_name]["collisionbox"] = table.copy(def.collisionbox)
+	
+	minetest.register_entity(entity_name, {
 		--Do simpler definition variables for ease of use
 		mob          = true,
-		name         = "open_ai:"..name,
+		name         = entity_name,
 		
 		collisionbox = def.collisionbox,--{-def.width/2,-def.height/2,-def.width/2,def.width/2,def.height/2,def.width/2},		
 		height       = def.collisionbox[2], --sample from bottom of collisionbox - absolute for the sake of math
@@ -1459,7 +1461,7 @@ open_ai.register_mob = function(name,def)
 		
 	})
 	
-	open_ai.register_safari_ball("open_ai:"..name,def.ball_color,math.abs(def.collisionbox[2]))
+	open_ai.register_safari_ball(entity_name,def.ball_color,math.abs(def.collisionbox[2]))
 	
 end
 

--- a/safari_ball.lua
+++ b/safari_ball.lua
@@ -99,8 +99,9 @@ minetest.register_entity("open_ai:safari_ball_no_mob", {
 --function that creates safari ball item and entity
 open_ai.register_safari_ball = function(mob_name, color,height)
 	local texture = "open_ai_safari_ball_top.png^[colorize:#"..color.."^open_ai_safari_ball_bottom.png"
+	local entity_name = minetest.get_current_modname()..":safari_ball_"..mob_name:match("^.-:(.*)")
 	--item
-	minetest.register_craftitem("open_ai:safari_ball_"..mob_name:match("^.-:(.*)"), {
+	minetest.register_craftitem(entity_name, {
 		--remove modname and capitalize first letter
 		description = "Safari Ball Containing "..mob_name:match("^.-:(.*)"):gsub("^%l", string.upper),
 		inventory_image = texture,
@@ -115,7 +116,7 @@ open_ai.register_safari_ball = function(mob_name, color,height)
 				gain = 10.0,
 				object = obj,
 			})
-			local obj = minetest.add_entity(pos, "open_ai:safari_ball_"..mob_name:match("^.-:(.*)"))
+			local obj = minetest.add_entity(pos, entity_name)
 			
 			obj:setvelocity({x = (v.x * 7)+vel.x, y = (v.y * 7 + 4)+vel.y, z = (v.z * 7)+vel.z})
 			obj:setacceleration({x = 0, y = -10, z = 0})
@@ -126,7 +127,7 @@ open_ai.register_safari_ball = function(mob_name, color,height)
 	})
 	
 	--entity
-	minetest.register_entity("open_ai:safari_ball_"..mob_name:match("^.-:(.*)"), {
+	minetest.register_entity(entity_name, {
 		physical = true,
 		collide_with_objects = false,
 		collisionbox = {-0.1, -0.1, -0.1, 0.1, 0.1, 0.1},


### PR DESCRIPTION
hard-coded prefix "open_ai" does not follow the naming conventions. The prefix should be the modname of the origin mod