### PR TITLE
Add configurable on-hit/death "blood" colour

### DIFF
--- a/ai/aesthetic.lua
+++ b/ai/aesthetic.lua
@@ -89,7 +89,7 @@ function ai_library.aesthetic:hurt_texture_normalize(self,dtime)
 				maxsize = 1,
 				collisiondetection = true,
 				vertical = false,
-				texture = "open_ai_dot_particle.png^[colorize:#CC0000:255",
+				texture = "open_ai_dot_particle.png^[colorize:#" .. self.hit_color .. ":255",
 			})
 		if self.fall_damaged_timer >= self.fall_damaged_limit then
 			self.fall_damaged_timer = nil
@@ -168,7 +168,7 @@ function ai_library.aesthetic:on_die(self)
 		maxsize = 1,
 		collisiondetection = true,
 		vertical = false,
-		texture = "open_ai_dot_particle.png^[colorize:#CC0000:255",
+		texture = "open_ai_dot_particle.png^[colorize:#" .. self.hit_color .. ":255",
 	})
 end
 

--- a/init.lua
+++ b/init.lua
@@ -165,6 +165,7 @@ open_ai.register_mob = function(name,def)
 		jumped       = false,
 		scale_size   = 1,
 		drops = def.drops,
+		hit_color = def.hit_color and def.hit_color or "CC0000",
 		
 		
 		--Pathfinding variables

--- a/mobs.lua
+++ b/mobs.lua
@@ -513,6 +513,9 @@ open_ai.register_mob("slime",{
 	--what a mob drops on death
 	drops = "dye:green",
 	
+	-- colour of "blood"
+	hit_color = "00CC00",
+
 	--user defined functions
 	on_step = function(self,dtime)
 		--print("test")


### PR DESCRIPTION
Mob author can configure the colour of the particles that are shown when it gets hit/dies