### PR TITLE
Update the on_punch and on_die methods

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -190,8 +190,8 @@ open_ai.register_mob = function(name,def)
 		get_staticdata = function(self)
 			return(self.ai_library.activation:getstaticdata(self))
 		end,
-		on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
-			self.ai_library.interaction:on_punch(self, puncher, time_from_last_punch, tool_capabilities, dir)
+		on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)
+			return self.ai_library.interaction:on_punch(self, puncher, time_from_last_punch, tool_capabilities, dir, damage)
 		end,
 		on_rightclick = function(self, clicker) 
 			self.ai_library.interaction:on_rightclick(self, clicker)


### PR DESCRIPTION
Update the interaction:on_punch() and interaction:on_die() methods to take account of changes in the way minetest calls on_punch since commit 814ee97 (Jan 28 2017 by sapier). Also move the check to see if mob is dead into interaction:on_punch(), so interaction:on_die() is only called if the mob is actually dead.